### PR TITLE
Fix: zero(::StarAlgebra) is of different type than (RG::StarAlgebra)(0)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StarAlgebras"
 uuid = "0c0c59c1-dc5f-42e9-9a8b-b5dc384a6cd1"
 authors = ["Marek Kaluba <kalmar@mailbox.org>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,24 +1,39 @@
-Base.show(io::IO, A::AbstractStarAlgebra) = print(io, "*-algebra of $(object(A))")
+Base.show(io::IO, A::AbstractStarAlgebra) =
+    print(io, "*-algebra of $(object(A))")
 
-__prints_with_minus(x) = false
+__prints_with_minus(::Any) = false
 __prints_with_minus(x::Real) = x < 0
+__needs_parens(::Any) = false
+__needs_parens(a::AlgebraElement) = true
+
+function _coeff_elt_print(io, c, elt)
+    print(io, c, "·")
+    __needs_parens(elt) && print(io, "(")
+    print(io, elt)
+    __needs_parens(elt) && print(io, ")")
+    return
+end
 
 function Base.show(io::IO, a::AlgebraElement)
     A = parent(a)
     if iszero(a)
         T = eltype(a)
-        print(io, "$(zero(T))·$(one(object(A)))")
+        if hasbasis(A)
+            _coeff_elt_print(io, zero(T), first(basis(A)))
+        else
+            print(io, zero(T))
+        end
     elseif hasbasis(A)
         elts = String[]
         nzeros = findall(!iszero, coeffs(a))
         for (counter, idx) in enumerate(nzeros)
             c, elt = coeffs(a)[idx], basis(A)[idx]
             if counter == 1
-                print(io, c, '·', elt)
-                length(nzeros) > 1 && print(io, ' ')
+                _coeff_elt_print(io, c, elt)
             else
+                print(io, ' ')
                 __prints_with_minus(c) || print(io, '+')
-                print(io, c, '·', elt)
+                _coeff_elt_print(io, c, elt)
                 counter == length(nzeros) || print(io, ' ')
             end
         end
@@ -33,4 +48,5 @@ function Base.show(io::IO, ::MIME"text/plain", mstr::TrivialMStructure)
     l = length(basis(mstr))
     Tw && print(io, "twisted ")
     print(io, "TrivialMStructure over basis with $l elements")
+    return
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,5 +1,7 @@
 Base.show(io::IO, A::AbstractStarAlgebra) =
     print(io, "*-algebra of $(object(A))")
+Base.show(io::IO, ::Type{<:StarAlgebra{O,T}}) where {O,T} =
+    print(io, "StarAlgebra{$O, $T, …}")
 
 __prints_with_minus(::Any) = false
 __prints_with_minus(x::Real) = x < 0

--- a/src/types.jl
+++ b/src/types.jl
@@ -74,7 +74,10 @@ Base.eltype(a::AlgebraElement) = eltype(coeffs(a))
 ### constructing elements
 
 function Base.zero(A::AbstractStarAlgebra, T = Int)
-    hasbasis(A) && return AlgebraElement(spzeros(T, length(basis(A))), A)
+    if hasbasis(A)
+        I = SparseArrays.indtype(basis(A))
+        return AlgebraElement(sparsevec(I[], T[], length(basis(A))), A)
+    end
     throw(
         "Algebra without basis; to construct zero use the `AlgebraElement` constructor directly.",
     )
@@ -113,7 +116,7 @@ let SA = @static VERSION < v"1.3.0" ? :StarAlgebra : :AbstractStarAlgebra
         function (A::$SA)(x::Number)
             g = one(object(A))
             res = A(g, typeof(x))
-            res = mul!(res, res, x)
+            res[g] *= x
             return res
         end
     end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -10,6 +10,9 @@
     @test AlgebraElement(a, RG) isa AlgebraElement
     @test all(RG(g) isa AlgebraElement{typeof(RG)} for g in b)
 
+    @test typeof(zero(RG)) == typeof(RG(0))
+    @test typeof(one(RG)) == typeof(RG(1))
+
     @test_throws AssertionError AlgebraElement([1, 2, 3], RG)
     @test AlgebraElement([1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], RG) isa AlgebraElement
 


### PR DESCRIPTION
Additionally:
* small changes to printing are introduced
* usability enhancement: drastic shortening of `Type{<:StarAlgebra}`

CC: @piotrmizerka